### PR TITLE
Adjust artemis logo query selector

### DIFF
--- a/artemis-artemogus.user.js
+++ b/artemis-artemogus.user.js
@@ -30,7 +30,7 @@ function replaceFavicon() {
 function replaceNavbarImage() {
     var callback = function (mutationsList, observer) {
         // As soon as our element exists, we replace its image
-        var elem = document.querySelector(".logo-img");
+        var elem = document.querySelector(".navbar-brand > img");
         if (elem) {
             elem.src = replacedHeaderImage;
 


### PR DESCRIPTION
Apparently the Artemis navbar was changed which prevented the old logo query selector from locating the image.
I adjusted the selector so that it can now find the image again.